### PR TITLE
fix: don't remove attrributes when value is set to null

### DIFF
--- a/src/main/java/com/mparticle/JSON.java
+++ b/src/main/java/com/mparticle/JSON.java
@@ -47,6 +47,7 @@ class JSON {
         gson = createGson()
             .registerTypeAdapter(OffsetDateTime.class, offsetDateTimeTypeAdapter)
             .registerTypeAdapter(LocalDate.class, localDateTypeAdapter)
+            .serializeNulls()
             .create();
     }
 


### PR DESCRIPTION
## Summary
McD reported that Java SDK drops any event or user attributes that are set to null. We use gson which is the Java library we use to convert Java Objects into JSON. By default, it doesn't serialize null values unless you allow it to by adding serializeNulls() in the createGson().

## Testing Plan
I compared the changes between a Batch before and after adding the fix to see if it affects anything else. Also, got in a zoom meeting with Will P for testing since this issue was occurring due to a library we're using and not per se code functionality missing.

## Master Issue
Closes https://go.mparticle.com/work/REPLACEME
