### PR TITLE
Fixed ConsentState class for purpose names

### DIFF
--- a/src/main/java/com/mparticle/model/ConsentState.java
+++ b/src/main/java/com/mparticle/model/ConsentState.java
@@ -3,6 +3,8 @@ package com.mparticle.model;
 import com.google.gson.annotations.SerializedName;
 import io.swagger.annotations.ApiModelProperty;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -12,10 +14,10 @@ import java.util.Objects;
 public class ConsentState {
   public static final String SERIALIZED_NAME_GDPR = "gdpr";
   @SerializedName(SERIALIZED_NAME_GDPR)
-  private GDPRConsentState gdpr = null;
+  private Map consentPurposes;
 
-  public ConsentState gdpr(GDPRConsentState gdpr) {
-    this.gdpr = gdpr;
+  public ConsentState gdpr(String purposeName, GDPRConsentState gdpr) {
+    this.consentPurposes.put(purposeName, gdpr);
     return this;
   }
 
@@ -24,12 +26,12 @@ public class ConsentState {
    * @return gdpr
   **/
   @ApiModelProperty(required = true, value = "")
-  public GDPRConsentState getGdpr() {
-    return gdpr;
+  public Map getGdpr() {
+    return consentPurposes;
   }
 
-  public void setGdpr(GDPRConsentState gdpr) {
-    this.gdpr = gdpr;
+  public void setGdpr(Map consentPurposes) {
+    this.consentPurposes = consentPurposes;
   }
 
 
@@ -42,12 +44,12 @@ public class ConsentState {
       return false;
     }
     ConsentState consentState = (ConsentState) o;
-    return Objects.equals(this.gdpr, consentState.gdpr);
+    return Objects.equals(this.consentPurposes, consentState.consentPurposes);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(gdpr);
+    return Objects.hash(consentPurposes);
   }
 
 
@@ -55,7 +57,7 @@ public class ConsentState {
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class ConsentState {\n");
-    sb.append("    gdpr: ").append(toIndentedString(gdpr)).append("\n");
+    sb.append("    gdpr: ").append(toIndentedString(consentPurposes)).append("\n");
     sb.append("}");
     return sb.toString();
   }


### PR DESCRIPTION
## Summary
Added an intermediate field for purpose name between "gdpr" and consent params like "document" etc. by replacing GDPRConsentState with a HashMap as the instance variable in ConsentState class

## Testing Plan
Tested by adding this code to [MainActivity.java in the sample app](https://github.com/mparticle-tse/javaSDKSample/blob/master/app/src/main/java/com/example/javasdksample/MainActivity.java), just before the `uploadEvents` call in `run()` method:
```
                    // GDPR Consent State
                    GDPRConsentState gdprConsentState = new GDPRConsentState();
                    gdprConsentState.setConsented(true);
                    gdprConsentState.setDocument("test_document");
                    gdprConsentState.setHardwareId("test_hardware_id");
                    gdprConsentState.setLocation("test_location");
                    gdprConsentState.setTimestampUnixtimeMs(System.currentTimeMillis());

                    Map purposes = new HashMap<>();
                    purposes.put("marketing", gdprConsentState);

                    ConsentState consentState = new ConsentState();
                    consentState.setGdpr(purposes);

                    batch.setConsentState(consentState);
```

Verified that mP received and processed the consent information successfully by checking "Event Data" in Live Stream and "Consent and Compliance" section in UAV

## Master Issue
Closes https://go.mparticle.com/work/REPLACEME
