### PR TITLE
feat: Added CCPA consent support

### DIFF
--- a/src/main/java/com/mparticle/model/ConsentPurpose.java
+++ b/src/main/java/com/mparticle/model/ConsentPurpose.java
@@ -6,10 +6,10 @@ import io.swagger.annotations.ApiModelProperty;
 import java.util.Objects;
 
 /**
- * GDPRConsentState
+ * ConsentPurpose
  */
 
-public class GDPRConsentState {
+public class ConsentPurpose {
   public static final String SERIALIZED_NAME_REGULATION = "regulation";
   @SerializedName(SERIALIZED_NAME_REGULATION)
   private String regulation;
@@ -34,7 +34,7 @@ public class GDPRConsentState {
   @SerializedName(SERIALIZED_NAME_HARDWARE_ID)
   private String hardwareId;
 
-  public GDPRConsentState regulation(String regulation) {
+  public ConsentPurpose regulation(String regulation) {
     this.regulation = regulation;
     return this;
   }
@@ -52,7 +52,7 @@ public class GDPRConsentState {
     this.regulation = regulation;
   }
 
-  public GDPRConsentState document(String document) {
+  public ConsentPurpose document(String document) {
     this.document = document;
     return this;
   }
@@ -70,7 +70,7 @@ public class GDPRConsentState {
     this.document = document;
   }
 
-  public GDPRConsentState consented(Boolean consented) {
+  public ConsentPurpose consented(Boolean consented) {
     this.consented = consented;
     return this;
   }
@@ -88,7 +88,7 @@ public class GDPRConsentState {
     this.consented = consented;
   }
 
-  public GDPRConsentState timestampUnixtimeMs(Long timestampUnixtimeMs) {
+  public ConsentPurpose timestampUnixtimeMs(Long timestampUnixtimeMs) {
     this.timestampUnixtimeMs = timestampUnixtimeMs;
     return this;
   }
@@ -106,7 +106,7 @@ public class GDPRConsentState {
     this.timestampUnixtimeMs = timestampUnixtimeMs;
   }
 
-  public GDPRConsentState location(String location) {
+  public ConsentPurpose location(String location) {
     this.location = location;
     return this;
   }
@@ -124,7 +124,7 @@ public class GDPRConsentState {
     this.location = location;
   }
 
-  public GDPRConsentState hardwareId(String hardwareId) {
+  public ConsentPurpose hardwareId(String hardwareId) {
     this.hardwareId = hardwareId;
     return this;
   }
@@ -151,13 +151,13 @@ public class GDPRConsentState {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    GDPRConsentState gdPRConsentState = (GDPRConsentState) o;
-    return Objects.equals(this.regulation, gdPRConsentState.regulation) &&
-        Objects.equals(this.document, gdPRConsentState.document) &&
-        Objects.equals(this.consented, gdPRConsentState.consented) &&
-        Objects.equals(this.timestampUnixtimeMs, gdPRConsentState.timestampUnixtimeMs) &&
-        Objects.equals(this.location, gdPRConsentState.location) &&
-        Objects.equals(this.hardwareId, gdPRConsentState.hardwareId);
+    ConsentPurpose purpose = (ConsentPurpose) o;
+    return Objects.equals(this.regulation, purpose.regulation) &&
+        Objects.equals(this.document, purpose.document) &&
+        Objects.equals(this.consented, purpose.consented) &&
+        Objects.equals(this.timestampUnixtimeMs, purpose.timestampUnixtimeMs) &&
+        Objects.equals(this.location, purpose.location) &&
+        Objects.equals(this.hardwareId, purpose.hardwareId);
   }
 
   @Override
@@ -169,7 +169,7 @@ public class GDPRConsentState {
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
-    sb.append("class GDPRConsentState {\n");
+    sb.append("class ConsentPurpose {\n");
     sb.append("    regulation: ").append(toIndentedString(regulation)).append("\n");
     sb.append("    document: ").append(toIndentedString(document)).append("\n");
     sb.append("    consented: ").append(toIndentedString(consented)).append("\n");

--- a/src/main/java/com/mparticle/model/ConsentState.java
+++ b/src/main/java/com/mparticle/model/ConsentState.java
@@ -14,24 +14,44 @@ import java.util.Objects;
 public class ConsentState {
   public static final String SERIALIZED_NAME_GDPR = "gdpr";
   @SerializedName(SERIALIZED_NAME_GDPR)
-  private Map consentPurposes;
+  private Map gdprPurposes;
 
-  public ConsentState gdpr(String purposeName, GDPRConsentState gdpr) {
-    this.consentPurposes.put(purposeName, gdpr);
+  static final String CCPA_PURPOSE_NAME = "data_sale_opt_out";
+  public static final String SERIALIZED_NAME_CCPA = "ccpa";
+  @SerializedName(SERIALIZED_NAME_CCPA)
+  private Map ccpaPurposes;
+
+  public ConsentState gdpr(String purposeName, ConsentPurpose gdprPurpose) {
+    this.gdprPurposes.put(purposeName, gdprPurpose);
     return this;
   }
 
-   /**
+  /**
    * Get gdpr
-   * @return gdpr
-  **/
+   * @return gdprPurposes
+   **/
   @ApiModelProperty(required = true, value = "")
   public Map getGdpr() {
-    return consentPurposes;
+    return gdprPurposes;
   }
 
-  public void setGdpr(Map consentPurposes) {
-    this.consentPurposes = consentPurposes;
+  public void setGdpr(Map gdprPurposes) {
+    this.gdprPurposes = gdprPurposes;
+  }
+
+  /**
+   * Get ccpa
+   * @return ccpaPurposes
+   **/
+  @ApiModelProperty(required = true, value = "")
+  public Map getCcpa() {
+    return ccpaPurposes;
+  }
+
+  public void setCcpa(ConsentPurpose ccpaPurpose) {
+    Map ccpa = new HashMap<>();
+    ccpa.put(CCPA_PURPOSE_NAME, ccpaPurpose);
+    this.ccpaPurposes = ccpa;
   }
 
 
@@ -44,12 +64,13 @@ public class ConsentState {
       return false;
     }
     ConsentState consentState = (ConsentState) o;
-    return Objects.equals(this.consentPurposes, consentState.consentPurposes);
+    return Objects.equals(this.gdprPurposes, consentState.gdprPurposes)
+            && Objects.equals(this.ccpaPurposes, consentState.ccpaPurposes);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(consentPurposes);
+    return Objects.hash(gdprPurposes, ccpaPurposes);
   }
 
 
@@ -57,7 +78,8 @@ public class ConsentState {
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class ConsentState {\n");
-    sb.append("    gdpr: ").append(toIndentedString(consentPurposes)).append("\n");
+    sb.append("    gdpr: ").append(toIndentedString(gdprPurposes)).append("\n");
+    sb.append("    ccpa: ").append(toIndentedString(ccpaPurposes)).append("\n");
     sb.append("}");
     return sb.toString();
   }


### PR DESCRIPTION
## Summary
Since the format of consent data expected by mParticle is the same for GDPR and CCPA, the class GDPRConsentState was renamed to a more regulation-agnostic name ConsentPurpose and refactored accordingly

## Testing Plan
Tested by adding this code to [MainActivity.java in the sample app](https://github.com/mparticle-tse/javaSDKSample/blob/master/app/src/main/java/com/example/javasdksample/MainActivity.java), just before the uploadEvents call in run() method:
```
                    // CCPA Consent State
                    ConsentPurpose purpose = new ConsentPurpose();
                    purpose.setConsented(true);
                    purpose.setDocument("test_document");
                    purpose.setHardwareId("test_hardware_id");
                    purpose.setLocation("test_location");
                    purpose.setTimestampUnixtimeMs(System.currentTimeMillis());

                    ConsentState consentState = new ConsentState();
                    consentState.setCcpa(purpose);

                    batch.setConsentState(consentState);
```
Verified that mP received and processed the consent information successfully by checking "Event Data" in Live Stream and "Consent and Compliance" section in UAV

## Reference Issue
- Closes https://go.mparticle.com/work/SQDSDKS-4750
