### PR TITLE
Update retrofit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,8 +15,8 @@ repositories {
     mavenCentral()
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_7
-targetCompatibility = JavaVersion.VERSION_1_7
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
 
 task sdkJavadocs(type: Javadoc) {
     source = sourceSets.main.allJava
@@ -42,7 +42,7 @@ artifacts {
 
 ext {
     oltu_version = "1.0.1"
-    retrofit_version = "2.3.0"
+    retrofit_version = "2.9.0"
     swagger_annotations_version = "1.5.22"
     junit_version = "4.12"
     threetenbp_version = "1.3.5"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Thu Aug 22 12:38:14 EDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6-all.zip


### PR DESCRIPTION
## Instructions
This PR primarily updates Retrofit to the latest version due to security vulnerabilities with the older version(s). As part of this I also am updating to target Java 8 and the latest version of Gradle that supports the bundled build scripts.
