### PR TITLE
fix: pin conventional commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
           -p @semantic-release/changelog@5 \
           -p @semantic-release/git@9 \
           -p @semantic-release/exec@5 \
-          -p conventional-changelog-conventionalcommits \
+          -p conventional-changelog-conventionalcommits@7 \
           semantic-release
 
   sonatype-release:


### PR DESCRIPTION
## Instructions
1. PR target branch should be against main
2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

## Summary
- change conventional commits to version 7, there was major version bump to 8 on 5/03/2024, which seems to have broken the release.

## Testing Plan
- yml file changes, so can not test locally.


## Reference Issue
- Closes https://go.mparticle.com/work/REPLACEME
