### PR TITLE
fix: make baseURL configurable.

### DIFF
--- a/src/main/java/com/mparticle/ApiClient.java
+++ b/src/main/java/com/mparticle/ApiClient.java
@@ -29,6 +29,7 @@ public class ApiClient {
   private Retrofit.Builder adapterBuilder;
   private JSON json;
   private static Long retryAfter = null;
+  private String baseUrl = "https://s2s.mparticle.com/v2";
 
   /**
    * Create an API client with your mParticle API key and secret
@@ -44,11 +45,15 @@ public class ApiClient {
     addAuthorization("basic", auth);
   }
 
+  public ApiClient(String apiKey, String apiSecret, String apiBaseUrl) {
+    this(apiKey, apiSecret);
+    this.baseUrl = apiBaseUrl;
+  }
+
   public void createDefaultAdapter() {
     json = new JSON();
     okBuilder = new OkHttpClient.Builder();
 
-    String baseUrl = "https://s2s.mparticle.com/v2";
     if (!baseUrl.endsWith("/"))
       baseUrl = baseUrl + "/";
 


### PR DESCRIPTION
For the [mparticle-kafka2mp](https://github.com/mParticle/mparticle-kafka2mp) package, the ApiClient needs to have a configurable baseURL. According to this doc, customers from different countries need different baseUrls: https://docs.mparticle.com/developers/apis/http/#base-url
Since the ApiClient is readonly for customers but uses an invalid baseUrl, I had to change this repo aswell.

There is a second pull request in this repo [mparticle-kafka2mp](https://github.com/mParticle/mparticle-kafka2mp).

 