### PR TITLE
ci: Add signingInMemoryKey to smoke test

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -62,6 +62,9 @@ jobs:
           cache: "gradle"
 
       - name: Smoke test - publish to Maven local
+        env:
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.MAVEN_CENTRAL_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.MAVEN_CENTRAL_SIGNING_KEY_PASSWORD }}
         run: ./gradlew publishToMavenLocal -PVERSION=${{ steps.bump-version.outputs.new_version }}
 
       - name: Create Pull Request


### PR DESCRIPTION
## Instructions
1. PR target branch should be against main
2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

## Summary
Add signing keys to smoke test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change; it only injects existing secrets into the Gradle smoke-test step and does not affect runtime code.
> 
> **Overview**
> The release-draft GitHub Actions workflow now passes Maven Central in-memory signing credentials (`ORG_GRADLE_PROJECT_signingInMemoryKey` and `...Password`) into the `publishToMavenLocal` smoke-test step, aligning the local publish check with signed-release requirements.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4fe1678d4e38cdde45f68c2884e7429d8546954f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->